### PR TITLE
chore(): change routerLink

### DIFF
--- a/src/app/pages/index.page.ts
+++ b/src/app/pages/index.page.ts
@@ -20,8 +20,8 @@ import { RouterLink } from '@angular/router';
             DaisyUi. AnalogJs is a framework for building web applications with
             web components.
           </p>
-          <button class="btn items-center bg-base-300">
-            <a routerLink="/blog">Go to Blog Posts</a>
+          <button class="btn items-center bg-base-300" routerLink="/blog">
+            <a>Go to Blog Posts</a>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Moved routerLink to button, instead of the anchor.

Link only worked when clicking the text "Go to Blog Posts", clicking other part of the button gave the user the feeling it was not working.